### PR TITLE
Adding support for specific step size in CSV output

### DIFF
--- a/gnuplot.go
+++ b/gnuplot.go
@@ -26,7 +26,7 @@ func gnuplotAction(c *cli.Context) error {
 	end := time.Now()
 	start := end.Add(-1 * gnuplotFlag.Duration)
 
-	results, err := Query(gnuplotFlag.Prometheus, start, end, c.Args().First())
+	results, err := Query(gnuplotFlag.Prometheus, start, end, c.Args().First(), 0)
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -17,6 +17,12 @@ func main() {
 
 	app.Action = exportAction
 	app.Flags = []cli.Flag{
+		cli.IntFlag{
+			Name:        "step,s",
+			Usage:       "Step size in result data, in seconds",
+			Value:       0,
+			Destination: &flag.Step,
+		},
 		cli.DurationFlag{
 			Name:        "duration,d",
 			Usage:       "The duration to get timeseries from",
@@ -90,6 +96,7 @@ type flags struct {
 	Duration   time.Duration
 	Header     bool
 	Prometheus string
+	Step       int
 }
 
 var flag flags
@@ -102,7 +109,7 @@ func exportAction(c *cli.Context) error {
 	end := time.Now()
 	start := end.Add(-1 * flag.Duration)
 
-	results, err := Query(flag.Prometheus, start, end, c.Args().First())
+	results, err := Query(flag.Prometheus, start, end, c.Args().First(), flag.Step)
 	if err != nil {
 		return err
 	}

--- a/matplotlib.go
+++ b/matplotlib.go
@@ -26,7 +26,7 @@ func matplotlibAction(c *cli.Context) error {
 	end := time.Now()
 	start := end.Add(-1 * matplotlibFlag.Duration)
 
-	results, err := Query(matplotlibFlag.Prometheus, start, end, c.Args().First())
+	results, err := Query(matplotlibFlag.Prometheus, start, end, c.Args().First(), 0)
 	if err != nil {
 		return err
 	}

--- a/prometheus.go
+++ b/prometheus.go
@@ -28,17 +28,22 @@ type Result struct {
 	Values map[string]string
 }
 
-func Query(host string, start time.Time, end time.Time, query string) ([]Result, error) {
+func Query(host string, start time.Time, end time.Time, query string, step int) ([]Result, error) {
 	u, err := url.Parse(host)
 	if err != nil {
 		return nil, err
 	}
+
+	if step == 0 {
+		step = steps(end.Sub(start))
+	}
+
 	u.Path = "/api/v1/query_range"
 	q := u.Query()
 	q.Set("query", query)
 	q.Set("start", fmt.Sprintf("%d", start.Unix()))
 	q.Set("end", fmt.Sprintf("%d", end.Unix()))
-	q.Set("step", fmt.Sprintf("%d", steps(end.Sub(start))))
+	q.Set("step", fmt.Sprintf("%d", step))
 	u.RawQuery = q.Encode()
 
 	response, err := http.Get(u.String())


### PR DESCRIPTION
Added flag --step, which is the step size in seconds.  This will
generate a line every step seconds.  Not specifying a step size,
or supplying a step size of 0 uses the previous step size
calculations.